### PR TITLE
Fix: Jumping out of V-shaped terrain

### DIFF
--- a/UltimatePlatformerController.gd
+++ b/UltimatePlatformerController.gd
@@ -632,7 +632,7 @@ func _jump():
 		velocity.y = -jumpMagnitude
 		jumpCount += -1
 		jumpWasPressed = false
-		coyoteActive = false
+		
 		
 func _wallJump():
 	var horizontalWallKick = abs(jumpMagnitude * cos(wallKickAngle * (PI / 180)))


### PR DESCRIPTION
V-shaped terrain with angles steeper than 45 degrees will trap the platformer controller in a way that doesn't feel right as a player.
`is_on_floor()` returns false because it's on a steep slope. But at the bottom of the V, standing on two opposing slopes,
while walking is not allowed, it would be appropriate to be able to jump and do other actions. So I'd like to contribute back the fix that I made for our project.

I made a demo of the bug, and of the fix, playable here: https://suddjian.github.io/upc2d-v-shaped-terrain/

We discovered this because we were using rectangular RigidBody2Ds as terrain. They'd often fall next to each other forming V-shaped gaps.

<img width="167" alt="Screenshot 2025-02-12 at 20 30 16" src="https://github.com/user-attachments/assets/f8fea43e-047f-42ef-83d1-ad826126cdaf" />
